### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/arx-test.el
+++ b/test/arx-test.el
@@ -1,11 +1,6 @@
 ;; -*- flycheck-disabled-checkers: (emacs-lisp-checkdoc) -*-
 ;; -*- no-byte-compile: t; -*-
 (require 'ert)
-(require 'test-helper
-         ;; let's try a bit to help Emacs find the helpers, just in case
-         (concat (file-name-directory (or load-file-name (buffer-file-name)
-                                          default-directory))
-                 "test-helper.el"))
 
 (ert-deftest arx-empty-list ()
   (with-myrx

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -21,6 +21,3 @@
      (let* ((result (should-error ,expr))
              (msg (cadr result)))
        (should (string-match ,pattern msg)))))
-
-
-(provide 'test-helper)


### PR DESCRIPTION
The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Fixes #5.