### PR TITLE
Add basic support for Emacs 27

### DIFF
--- a/ample-regexps.el
+++ b/ample-regexps.el
@@ -349,8 +349,11 @@ Use function `%s-to-string' to do such a translation at run-time."
        ;; Define MACRO-to-string function.
        (defun ,macro-to-string (form &optional no-group)
          ,(arx--make-macro-to-string-docstring macro-name)
-         (let ((rx-constituents ,macro-constituents))
-           (rx-to-string form no-group)))
+         ,(if (fboundp 'rx-check)
+              `(let ((rx-constituents ,macro-constituents))
+                 (rx-to-string form no-group))
+            `(rx-let-eval ',form-defs
+               (rx-to-string form no-group))))
 
        ;; Define MACRO.
        (defmacro ,macro (&rest regexps)


### PR DESCRIPTION
In Emacs 27 the `rx` library is rewritten and the old way of adding forms with `rx-constituents` is deprecated. Many of the functions this package relies on such as `rx-check` and `rx-forms` no longer exist. This means that `arx` in its current form does not work on Emacs 27.

As part of tthe upgrade to `rx` Emacs added some new features such as `rx-define` and `rx-let` that overlap a lot of this packages functionality. The new system does not support functions per se, but it does have a new template system that is just as powerful. For example I have taken 3 of the function forms from the readme and translated them to their Emacs 27 template equivalents. These generate the same output as the Emacs 26 versions with this patch.

```lisp
(define-arx cond-assignment-rx
  '((alpha_ (regexp "[[:alpha:]_]"))
    (alnum_ (regexp "[[:alnum:]_]"))
    (ws (* blank))
    (sym (&rest args)
         (seq symbol-start (or args) symbol-end))
    (cond-keyword (sym "if" "elif" "while"))
    (id (sym (+ alpha_) (* alnum_)))))

(cond-assignment-rx cond-keyword ws id ":" id ws "=" ws id)
``` 

```lisp
(define-arx csv-rx
  '((csv (n arg)
         (eval `(seq ,@(nbutlast
                        (cl-loop for i from 1 to n
                                 collect `(group-n ,i arg)
                                 collect ", ")))))))

(csv-rx (csv 3 (seq "foobar")))
```
```lisp
(defun csv-opt (n elt &optional accum)
  (cond
   ((<= n 0) accum)
   ((null accum) (list 'csv-opt (1- n) elt `(quote (group-n ,n ,elt))))
   (t (list 'csv-opt (1- n) elt `(quote (group-n ,n ,elt (opt ", " ,accum)))))))

(define-arx csv-opt-rx
  '((csv-opt (n elt &rest accum)
             (eval (csv-opt n elt accum)))))

(csv-opt-rx (csv-opt 3 "foo"))
```
This should give you a feel for how the new system works. This change is not comprehensive, but it should at very least keep most peoples arx forms from breaking when the upgrade to 27.1.